### PR TITLE
Disable git rename detection in gen_update.sh

### DIFF
--- a/gen_update.sh
+++ b/gen_update.sh
@@ -54,7 +54,7 @@ rsync -a "$HOME/$REPO_ROOT/$REPO_FRONTEND/bin/" "$UPDATE_DIR/opt/muos/extra/"
 cd "$HOME/$REPO_ROOT/$REPO_INTERNAL"
 
 # Grab the file diff of all changes based on commit to commit
-git diff --name-status "$FROM_COMMIT" "$TO_COMMIT" >"$CHANGE_DIR/commit.txt"
+git diff --name-status --no-renames "$FROM_COMMIT" "$TO_COMMIT" >"$CHANGE_DIR/commit.txt"
 
 # Create 'deleted.txt' file containing deleted files
 grep '^D' "$CHANGE_DIR/commit.txt" | cut -f2 >"$CHANGE_DIR/deleted.txt"


### PR DESCRIPTION
Without this, Git "helpfully" detects renames and prints them in the diff like so:

```
R100    backup/info/config/.gitkeep     backup/MUOS/info/config/.gitkeep
R083    config/gptokeyb/ext-drastic.gptk        config/gptokeyb/ext-drastic-legacy.gptk
```

Which means these renamed files don't show up in the update archive.

With `--no-renames`, we get an add/remove instead, and all is well:

```
A       backup/MUOS/info/config/.gitkeep
D       backup/info/config/.gitkeep
A       config/gptokeyb/ext-drastic-legacy.gptk
D       config/gptokeyb/ext-drastic.gptk
```