### PR TITLE
Back up initial info/config during rootfs update

### DIFF
--- a/update_rootfs.sh
+++ b/update_rootfs.sh
@@ -55,6 +55,9 @@ done
 printf "\n\t\033[1m- Updating muOS Frontend\033[0m\n"
 rsync -a --info=progress2 "$HOME/$REPO_DIR/frontend/bin/" "$MOUNT_POINT/opt/muos/extra/"
 
+printf "\n\t\033[1m- Backing Up Initial Configs\033[0m\n"
+rsync -a --info=progress2 "$HOME/$REPO_DIR/internal/init/MUOS/info/config/" "$MOUNT_POINT/opt/muos/backup/MUOS/info/config/"
+
 printf "\n\t\033[1m- Removing Leftover Files\033[0m\n"
 rm -rf "$MOUNT_POINT/opt/muos/.git" \
 	"$MOUNT_POINT/opt/muos/LICENSE" \


### PR DESCRIPTION
Goes along with https://github.com/MustardOS/internal/pull/330. Populates the backup copy of the default `MUOS/info/config` files for the "Restore RetroArch Overrides" task while updating the rootfs.

May need some more thought? I don't love having a special case for this one script (though I also think it would be handy to keep more of the default files around for folks to be able to easily restore them). Also still need to figure out how to get this to work nicely with incremental updates....