### PR TITLE
Include backup configs in incremental upgrades

### DIFF
--- a/gen_update.sh
+++ b/gen_update.sh
@@ -45,10 +45,13 @@ fi
 ARCHIVE_NAME="muOS-$VERSION-$TO_COMMIT-UPDATE.zip"
 
 # Create temporary directory structure for both update archive and diff file stuff
-mkdir -p "$MU_UDIR" "$CHANGE_DIR" "$UPDATE_DIR/opt/muos/extra" "$UPDATE_DIR/mnt/mmc/MUOS"
+mkdir -p "$MU_UDIR" "$CHANGE_DIR" "$UPDATE_DIR/opt/muos/extra" "$UPDATE_DIR/opt/muos/backup/MUOS/info/config" "$UPDATE_DIR/mnt/mmc/MUOS"
 
 # Update frontend binaries
 rsync -a "$HOME/$REPO_ROOT/$REPO_FRONTEND/bin/" "$UPDATE_DIR/opt/muos/extra/"
+
+# Update backup configs
+rsync -a "$HOME/$REPO_ROOT/$REPO_INTERNAL/init/MUOS/info/config/" "$UPDATE_DIR/opt/muos/backup/MUOS/info/config/"
 
 # Let's go to the internal directory - away we go!
 cd "$HOME/$REPO_ROOT/$REPO_INTERNAL"


### PR DESCRIPTION
Complement to #3 so we can actually get these populated in the Banana patch. It's not a lot of files, so for now, I'm just copying all of them into every update archive, like we do for the frontend binaries.

But that feels hacky, and I'm not really happy with it for the long haul. I wonder if it would be cleaner to first build a full version of `/opt/muos` and `/mnt/mmc` for both the old and new versions, and then use `rsync --compare-dest` to [generate the incremental update](https://developers.shopware.com/blog/2015/07/16/create-delta-updates-using-rsync/) rather than relying on `git diff`. (We'd still need some special handling of deleted files, but `rsync --itemize-changes` may be helpful there....)