### PR TITLE
Hide error when trying to remove empty directory

### DIFF
--- a/gen_update.sh
+++ b/gen_update.sh
@@ -197,7 +197,7 @@ fi
 if [ -s "$CHANGE_DIR/deleted_dirs.txt" ]; then
 	printf '\n' >>"update.sh"
 	# Print rmdir commands in reverse so we remove foo/bar before foo
-	sort -r "$CHANGE_DIR/deleted_dirs.txt" | GEN_DELETES -d rmdir >>"update.sh"
+	sort -r "$CHANGE_DIR/deleted_dirs.txt" | GEN_DELETES -d 'rmdir 2>/dev/null' >>"update.sh"
 fi
 
 # Remove the temporary copy of the inner archive


### PR DESCRIPTION
Small thing, but since we intentionally only delete directories on update when they're empty (to avoid removing directories where the user added their own files), we may as well hide the corresponding error messages when they end up being nonempty.